### PR TITLE
Fix psych disallowed class loading

### DIFF
--- a/lib/locode.rb
+++ b/lib/locode.rb
@@ -8,7 +8,7 @@ require_relative 'locode/location'
 module Locode
 
   def self.load_data
-    YAML.load(File.read(File.expand_path('../../data/yaml/dump.yml', __FILE__)))
+    YAML.unsafe_load(File.read(File.expand_path('../../data/yaml/dump.yml', __FILE__)))
   end
   private_class_method :load_data
 


### PR DESCRIPTION
Uses `:unsafe_load` instead of psych 4.x `load` -> `safe_load`.